### PR TITLE
Add `package.xml` to be listed in FreeCAD Addon Manager

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>pyOpTools Workbench</name> <!-- What the Addon Manager displays to users -->
+  <description>An optics ray-tracing workbench based on pyOpTools</description>
+  <version>1.0.1</version> <!-- Semantic versioning (1.2.3-beta) or CalVer-based, (2022.01.07), don't omit or non-git installations won't see your updates -->
+  <date>2022-01-07</date> <!-- Date of the last update to the version number -->
+  <maintainer email="your_address@null.com">Your Name</maintainer>
+  <license file="LICENSE">GPL-3</license> <!-- Make sure you actually have this file in your Addon repo if the license requires it -->
+  <url type="repository" branch="master">https://github.com/cihologramas/freecad-pyoptools</url> <!-- Don't forget to update the branch name here -->
+  <url type="readme">https://github.com/cihologramas/freecad-pyoptools/blob/master/README.md</url> <!-- Link to the HTML-rendered README page -->
+  <icon>freecad/pyoptools/resources/pyoptools.png</icon> <!-- If you include your icon here, you don't have to submit it to the main FreeCAD repo -->
+  <content>
+    <workbench>
+      <classname>PyOpToolsWorkbench</classname> <!-- Must match class name in InitGui.py -->
+      <subdirectory>./freecad/pyoptools/</subdirectory>
+      <depend>pyoptools</depend>
+      
+      <tag>raytracing</tag>
+      <tag>optics</tag>
+    </workbench>
+  </content>
+</package>


### PR DESCRIPTION
Modifed based on https://wiki.freecad.org/Package_Metadata#Examples

Closes #1

Note: the .xml has placeholders that need to be updated. Please review and modify accordingly.